### PR TITLE
chore(figma): bump patch versions fragments packages

### DIFF
--- a/fragments/fragments-cli/package.json
+++ b/fragments/fragments-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atls/figma-fragments-cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "src/index.ts",

--- a/fragments/fragments-generator/package.json
+++ b/fragments/fragments-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atls/figma-fragments-generator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "BSD-3-Clause",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Задача #40 

Бампнул версии, увидел [ошибку](https://github.com/atls/figma/actions/runs/12827440446/job/35769402120#step:10:56) в прошлом PR #50 
```
[@atls/figma-fragments-generator]: ➤ YN0000: @atls/figma-fragments-generator@workspace:fragments/fragments-generator: Bumped to 0.2.1
[@atls/figma-fragments-generator]: ➤ YN0000: Couldn't auto-upgrade range * (in @atls/figma-fragments-cli@workspace:fragments/fragments-cli)
[@atls/figma-fragments-generator]: ➤ YN0001: Error: ENOENT: no such file or directory, open '/home/runner/work/figma/figma/.yarn/versions/e2664a58.yml'
[@atls/figma-fragments-generator]: ➤ YN0000: Failed with errors in 0s 10ms
```